### PR TITLE
feat: add Port Annotation in ddd.stereotype

### DIFF
--- a/patternity-annotations/src/main/java/com/patternity/annotation/ddd/stereotype/Port.java
+++ b/patternity-annotations/src/main/java/com/patternity/annotation/ddd/stereotype/Port.java
@@ -1,0 +1,21 @@
+package com.patternity.annotation.ddd.stereotype;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Represents a port, the medium through which business logic is accessed.
+ * Port is a use case boundary i.e. Ports correspond to use-cases in the application.
+ *
+ * @see <a
+ *      href="http://codingcanvas.com/hexagonal-architecture/">Port</a>
+ *
+ * @author Youen.Chéné
+ */
+@Retention(RetentionPolicy.CLASS)
+@Inherited
+@Documented
+public @interface Port {
+}


### PR DESCRIPTION
I just started setting up hexagonal architecture on my new project.

This annotation is useful to identify a port.

Example in kotlin :

package com.saagie.tooling.featurebrawl.domain.ports.secondary

import com.patternity.annotation.ddd.stereotype.Port
import com.saagie.tooling.featurebrawl.model.Feature

@Port
interface FeatureRecords {

    fun getAllFeatures() : List<Feature>

}

I am quite new at DDD and hexagonal architecture, so any feedbacks welcome. I may miss something.

